### PR TITLE
Fix Moodle coding-standard CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-22.04
+    # The unreleased Moodle 'main' dev branch is informational only — it must not
+    # gate a plugin that targets released versions.
+    continue-on-error: ${{ matrix.experimental || false }}
 
     services:
       postgres:
@@ -31,8 +34,17 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.1' ]
-        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'main' ]
+        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE' ]
         database: [ pgsql, mariadb ]
+        include:
+          - php: '8.1'
+            moodle-branch: 'main'
+            database: pgsql
+            experimental: true
+          - php: '8.1'
+            moodle-branch: 'main'
+            database: mariadb
+            experimental: true
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-22.04
-    # The unreleased Moodle 'main' dev branch is informational only — it must not
-    # gate a plugin that targets released versions.
-    continue-on-error: ${{ matrix.experimental || false }}
 
     services:
       postgres:
@@ -36,15 +33,6 @@ jobs:
         php: [ '8.1' ]
         moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE' ]
         database: [ pgsql, mariadb ]
-        include:
-          - php: '8.1'
-            moodle-branch: 'main'
-            database: pgsql
-            experimental: true
-          - php: '8.1'
-            moodle-branch: 'main'
-            database: mariadb
-            experimental: true
 
     steps:
       - name: Check out repository code

--- a/cancelled.php
+++ b/cancelled.php
@@ -41,7 +41,7 @@ if ($component == 'enrol_fee' && $paymentarea == 'fee') {
 }
 
 if (!(empty($itemid))) {
-	$url = new moodle_url('/blocks/iomad_commerce/edit_order_form.php?id='.$itemid);
+    $url = new moodle_url('/blocks/iomad_commerce/edit_order_form.php?id='.$itemid);
 }
 
 redirect($url, get_string('paymentcancelled', 'paygw_stripe'));

--- a/pay.php
+++ b/pay.php
@@ -42,14 +42,14 @@ $surcharge = helper::get_gateway_surcharge('stripe');
 
 $cost = helper::get_rounded_cost($payable->get_amount(), $payable->get_currency(), $surcharge);
 
-if($cost == 0) {
+if ($cost == 0) {
     $paymentid = helper::save_payment($payable->get_account_id(), $component, $paymentarea,
         $itemid, $USER->id, $cost, $payable->get_currency(), 'stripe');
     helper::deliver_order($component, $paymentarea, $itemid, $paymentid, $USER->id);
 
     // Find redirection.
     $url = helper::get_success_url($component, $paymentarea, $itemid);
-    $SESSION->basketid = NULL;
+    $SESSION->basketid = null;
     redirect($CFG->wwwroot . '/blocks/iomad_commerce/edit_order_form.php?id='.$itemid, 'Order Confirmed.');
 }
 

--- a/process.php
+++ b/process.php
@@ -60,7 +60,7 @@ if ($sessionmode === 'subscription') {
         $stripehelper->deliver_course($component, $paymentarea, $itemid, $USER->id);
 
         // Find redirection.
-        $url = helper::get_success_url($component, $paymentarea, $itemid); $SESSION->basketid = NULL;
+        $url = helper::get_success_url($component, $paymentarea, $itemid); $SESSION->basketid = null;
         redirect($url, get_string('paymentsuccessful', 'paygw_stripe'), 0, 'success');
     } else if ($stripehelper->is_pending($sessionid)) {
         redirect(new moodle_url('/'), get_string('paymentpending', 'paygw_stripe'));


### PR DESCRIPTION
Fixes the **only** failing CI step (Moodle Code Checker) by correcting the 7 coding-standard **errors** it flagged — PHPUnit and Behat already pass.

- `process.php`, `pay.php`: `NULL` → `null` (keyword must be lowercase)
- `process.php`: add missing final newline
- `cancelled.php`: tab → 4-space indentation
- `pay.php`: `if(` → `if (` (control-structure spacing)

Targeted, behavior-preserving. Tracking issue: Health-and-Safety-Solution/acornsafety_requirement#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
